### PR TITLE
Add Options page

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -14,5 +14,6 @@
   "icons": {
     
     "128": "icons/logo.png"
-  }
+  },
+  "options_page": "options.html"
 }

--- a/frontend/public/options.html
+++ b/frontend/public/options.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Extension Options</title>
+    <style>
+        /* Add your custom CSS styles here */
+    </style>
+</head>
+<body>
+    <h1>Extension Options</h1>
+    
+    <!-- Add your options form or content here -->
+    
+    <script>
+        // Add your JavaScript code here
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add options page as defined in #3.

Modified the manifest.json to add:
```json
{
...
  "options_page": "options.html"
...
}
```

Currently I have only added an options.html as the options page in public. However, in the future I will make use of vite to create a multipage application as defined here: https://vitejs.dev/guide/build.html#multi-page-app